### PR TITLE
Bug Fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 **[插件地址：https://github.com/lhmyy521125/dataTables.treeGrid](https://github.com/lhmyy521125/dataTables.treeGrid)**
 # 更新日志
-2020-10-13: resetTreeGridRows 会提示datatable变量缺失问题解决；多次刷新页面时有时，多层数据中父子层级id相同导致收缩失败的问题解决；
+2020-10-13: resetTreeGridRows 会提示datatable变量缺失问题解决；多次刷新页面时有时，多层数据中父子层级id相同导致收缩失败的问题解决； 
+
 2020-4-16：千呼万唤始出来,很多朋友再CSDN博客上反馈了插件的一些问题，博主的公司因为已经很少用dataTable（都使用VUE啦）所以很少去弄这款插件了，今天呢总算抽时间完善了这款插件，更新内容如下：
 - 1、解决dataTable reload() / draw() 时树形失效问题
 - 2、采用新的初始化方式，可以外部调用 expandAll() / collapseAll() 方法

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 **[插件地址：https://github.com/lhmyy521125/dataTables.treeGrid](https://github.com/lhmyy521125/dataTables.treeGrid)**
 # 更新日志
+2020-10-13: resetTreeGridRows 会提示datatable变量缺失问题解决；多次刷新页面时有时，多层数据中父子层级id相同导致收缩失败的问题解决；
 2020-4-16：千呼万唤始出来,很多朋友再CSDN博客上反馈了插件的一些问题，博主的公司因为已经很少用dataTable（都使用VUE啦）所以很少去弄这款插件了，今天呢总算抽时间完善了这款插件，更新内容如下：
 - 1、解决dataTable reload() / draw() 时树形失效问题
 - 2、采用新的初始化方式，可以外部调用 expandAll() / collapseAll() 方法

--- a/dataTables.treeGrid.js
+++ b/dataTables.treeGrid.js
@@ -148,7 +148,7 @@
                 td.removeClass('treegrid-control-open').addClass('treegrid-control');
                 td.html('').append(icon);
 
-                resetTreeGridRows(parentTrId);
+                resetTreeGridRows(dataTable, parentTrId);
                 resetEvenOddClass(dataTable);
 
                 select && setTimeout(function () {
@@ -228,7 +228,7 @@
             trs.each(function (index, tr) {
                 if(typeof($(tr).attr("parent-index"))=="undefined"){
                     var trid = $(tr).attr('id');
-                    resetTreeGridRows(trid);
+                    resetTreeGridRows(dataTable, trid);
                 }
             });
         },
@@ -256,13 +256,13 @@
      * 收缩展开处理
      * @param trId
      */
-    function resetTreeGridRows (trId) {
+    function resetTreeGridRows(dataTable, trId) {
         var subRows = treeGridRows[trId];
         if (subRows && subRows.length) {
             subRows.forEach(function (node) {
                 var subTrId = $(node).attr('id');
                 if (treeGridRows[subTrId]) {
-                    resetTreeGridRows(subTrId);
+                    resetTreeGridRows(dataTable, subTrId);
                 }
                 dataTable.row($(node)).remove();
                 $(node).remove();
@@ -401,7 +401,8 @@
     };
 
     function getTrId() {
-        return 'tr-' + Date.now();
+
+        return 'tr-' + Date.now() + '-' + Math.random().toString().substr(3, 10);
     }
 
     function getParentTr(target) {


### PR DESCRIPTION
最近使用这个组件，遇到了一些问题，做了一些修改。希望能帮助完善这个组件，为后来的人更好的使用做点贡献。

问题列表
resetTreeGridRows 会提示datatable变量缺失问题解决，原因（函数层级问题导致变量缺失）
多次刷新页面时有时，多层数据中父子层级id相同导致收缩失败的问题解决；